### PR TITLE
Fix canvas ticket text rendering and adjust typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
             font-variation-settings: 'wght' 400;
             background-color: #80D8C2; /* Color verde esmeralda pastel */
             color: #000;
+            font-size: 1.125rem; /* Texto más grande para mejor legibilidad */
+            line-height: 1.6;
         }
 
         /* Usamos 'Gazzetta-Custom' para que el título use la fuente correcta */
@@ -105,7 +107,7 @@
 </head>
 <body class="bg-emerald-200 text-black min-h-screen flex flex-col items-center p-4">
 
-    <h1 class="text-3xl md:text-5xl gazzetta-medium-slanted text-center my-8">TS12 Release Party Ticket</h1>
+    <h1 class="text-4xl md:text-6xl gazzetta-medium-slanted text-center my-8">TS12 Release Party Ticket</h1>
 
     <div class="w-full max-w-2xl bg-black bg-opacity-50 p-6 rounded-lg shadow-xl mb-8">
         <div class="ticket-container">
@@ -320,7 +322,31 @@
                 const canvas = document.createElement('canvas');
                 const img = new Image();
                 img.crossOrigin = 'anonymous'; // Important for CORS if using external image URLs
-                
+
+                const textElements = [
+                    { text: (venueSelect.value === 'Otro' ? otherVenueInput.value : venueSelect.value).toUpperCase(), x: FINAL_AND_LIVE_COORDS.venue.x, y: FINAL_AND_LIVE_COORDS.venue.y, rotate: FINAL_AND_LIVE_COORDS.venue.rotate, size: FINAL_AND_LIVE_COORDS.venue.size },
+                    { text: fechaSelect.value.toUpperCase().replace('OCT', 'OCTUBRE'), x: FINAL_AND_LIVE_COORDS.fecha.x, y: FINAL_AND_LIVE_COORDS.fecha.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.fecha.size },
+                    { text: salaSelect.value.toUpperCase(), x: FINAL_AND_LIVE_COORDS.sala.x, y: FINAL_AND_LIVE_COORDS.sala.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.sala.size },
+                    { text: filaSelect.value.toUpperCase(), x: FINAL_AND_LIVE_COORDS.fila.x, y: FINAL_AND_LIVE_COORDS.fila.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.fila.size },
+                    { text: asientoSelect.value.toUpperCase(), x: FINAL_AND_LIVE_COORDS.asiento.x, y: FINAL_AND_LIVE_COORDS.asiento.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.asiento.size },
+                ].filter(item => item.text);
+
+                // Esperamos a que las fuentes personalizadas estén listas antes de dibujar en el canvas
+                if (document.fonts) {
+                    const fontPromises = textElements.map(item => `${item.size}px 'Gazzetta-Custom'`)
+                        .filter((value, index, self) => self.indexOf(value) === index)
+                        .map(fontSpec => document.fonts.load(fontSpec));
+
+                    await document.fonts.ready;
+                    if (fontPromises.length) {
+                        try {
+                            await Promise.all(fontPromises);
+                        } catch (error) {
+                            console.warn('No se pudo cargar la fuente personalizada en canvas:', error);
+                        }
+                    }
+                }
+
                 return new Promise((resolve, reject) => {
                     img.onload = () => {
                         const originalWidth = img.width;
@@ -329,28 +355,19 @@
                         canvas.height = originalHeight;
                         const ctx = canvas.getContext('2d');
                         ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-                        
+
                         // Set text properties for final generation
                         ctx.fillStyle = '#2e5950';
                         ctx.textAlign = 'left';
-
-                        const textElements = [
-                            { text: (venueSelect.value === 'Otro' ? otherVenueInput.value : venueSelect.value).toUpperCase(), x: FINAL_AND_LIVE_COORDS.venue.x, y: FINAL_AND_LIVE_COORDS.venue.y, rotate: FINAL_AND_LIVE_COORDS.venue.rotate, size: FINAL_AND_LIVE_COORDS.venue.size },
-                            { text: fechaSelect.value.toUpperCase().replace('OCT', 'OCTUBRE'), x: FINAL_AND_LIVE_COORDS.fecha.x, y: FINAL_AND_LIVE_COORDS.fecha.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.fecha.size },
-                            { text: salaSelect.value.toUpperCase(), x: FINAL_AND_LIVE_COORDS.sala.x, y: FINAL_AND_LIVE_COORDS.sala.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.sala.size },
-                            { text: filaSelect.value.toUpperCase(), x: FINAL_AND_LIVE_COORDS.fila.x, y: FINAL_AND_LIVE_COORDS.fila.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.fila.size },
-                            { text: asientoSelect.value.toUpperCase(), x: FINAL_AND_LIVE_COORDS.asiento.x, y: FINAL_AND_LIVE_COORDS.asiento.y, rotate: 0, size: FINAL_AND_LIVE_COORDS.asiento.size },
-                        ];
+                        ctx.textBaseline = 'top';
 
                         textElements.forEach(item => {
-                            // Aplicar la fuente personalizada y el tamaño
-                            // Aseguramos que el nombre de la fuente sea el mismo que el @font-face
-                            ctx.font = `${item.size}px 'Gazzetta-Custom'`;
                             ctx.save();
                             ctx.translate(item.x, item.y);
                             if (item.rotate) {
                                 ctx.rotate(item.rotate * Math.PI / 180);
                             }
+                            ctx.font = `${item.size}px Gazzetta-Custom, sans-serif`;
                             ctx.fillText(item.text, 0, 0);
                             ctx.restore();
                         });
@@ -362,7 +379,7 @@
                         reject(new Error('No se pudo cargar la imagen base.'));
                     };
                     // Usamos la misma fuente que la vista en vivo para consistencia y mitigar CORS
-                    img.src = baseImage.src; 
+                    img.src = baseImage.src;
                 });
             }
 


### PR DESCRIPTION
## Summary
- ensure custom text values are added to the generated ticket by waiting for font loading before drawing on the canvas
- keep the ticket preview readable by filtering empty values and drawing text with the branded typeface and baseline adjustments
- increase the base body font size and enlarge the page title for better legibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d149cc988321b3b00c88e964aa1c