### PR TITLE
Adjust asset paths for relative loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <style>
         @font-face {
             font-family: 'Gazzetta-Custom';
-            src: url('/GazzettaMediumSlanted.otf') format('opentype');
+            src: url('./GazzettaMediumSlanted.otf') format('opentype');
             /* Agrega 'format('woff')' si tienes un archivo .woff para mejor compatibilidad */
             font-weight: 400;
             font-style: normal;
@@ -110,7 +110,7 @@
     <div class="w-full max-w-2xl bg-black bg-opacity-50 p-6 rounded-lg shadow-xl mb-8">
         <div class="ticket-container">
             <!-- RUTA DE IMAGEN ALINEADA CON EL CÓDIGO LOCAL DEL USUARIO -->
-            <img id="baseImage" src="/boletovacio.webp" alt="Boleto base" class="w-full h-auto rounded-lg" crossorigin="anonymous">
+            <img id="baseImage" src="./boletovacio.webp" alt="Boleto base" class="w-full h-auto rounded-lg" crossorigin="anonymous">
             <div id="ticketOverlay"></div>
         </div>
 


### PR DESCRIPTION
## Summary
- load the Gazzetta custom font via a relative path so it resolves from subdirectories
- update the base ticket image to use a relative source path for correct loading in subfolders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d7514ab8832193ffbc7a844fffed